### PR TITLE
Add cfg conditionals to support compiling on non-x86 targets

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@
 //! ```
 
 extern crate simdeez;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub mod avx2;
 pub mod cellular;
 pub mod cellular_64;
@@ -91,9 +92,12 @@ pub mod scalar;
 mod shared;
 pub mod simplex;
 pub mod simplex_64;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub mod sse2;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub mod sse41;
 
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 macro_rules! get_1d_noise {
     ($setting:expr) => {
         if is_x86_feature_detected!("avx2") {
@@ -108,6 +112,14 @@ macro_rules! get_1d_noise {
     };
 }
 
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+macro_rules! get_1d_noise {
+    ($setting:expr) => {
+        unsafe { scalar::get_1d_noise($setting) }
+    };
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 macro_rules! get_2d_noise {
     ($setting:expr) => {
         if is_x86_feature_detected!("avx2") {
@@ -122,6 +134,14 @@ macro_rules! get_2d_noise {
     };
 }
 
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+macro_rules! get_2d_noise {
+    ($setting:expr) => {
+        unsafe { scalar::get_2d_noise($setting) }
+    };
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 macro_rules! get_3d_noise {
     ($setting:expr) => {
         if is_x86_feature_detected!("avx2") {
@@ -136,6 +156,14 @@ macro_rules! get_3d_noise {
     };
 }
 
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+macro_rules! get_3d_noise {
+    ($setting:expr) => {
+        unsafe { scalar::get_3d_noise($setting) }
+    };
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 macro_rules! get_4d_noise {
     ($setting:expr) => {
         if is_x86_feature_detected!("avx2") {
@@ -150,6 +178,14 @@ macro_rules! get_4d_noise {
     };
 }
 
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+macro_rules! get_4d_noise {
+    ($setting:expr) => {
+        unsafe { scalar::get_4d_noise($setting) }
+    };
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 macro_rules! get_1d_scaled_noise {
     ($setting:expr) => {
         if is_x86_feature_detected!("avx2") {
@@ -164,6 +200,14 @@ macro_rules! get_1d_scaled_noise {
     };
 }
 
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+macro_rules! get_1d_scaled_noise {
+    ($setting:expr) => {
+        unsafe { scalar::get_1d_scaled_noise($setting) }
+    };
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 macro_rules! get_2d_scaled_noise {
     ($setting:expr) => {
         if is_x86_feature_detected!("avx2") {
@@ -178,6 +222,14 @@ macro_rules! get_2d_scaled_noise {
     };
 }
 
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+macro_rules! get_2d_scaled_noise {
+    ($setting:expr) => {
+        unsafe { scalar::get_2d_scaled_noise($setting) }
+    };
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 macro_rules! get_3d_scaled_noise {
     ($setting:expr) => {
         if is_x86_feature_detected!("avx2") {
@@ -192,6 +244,14 @@ macro_rules! get_3d_scaled_noise {
     };
 }
 
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+macro_rules! get_3d_scaled_noise {
+    ($setting:expr) => {
+        unsafe { scalar::get_3d_scaled_noise($setting) }
+    };
+}
+
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 macro_rules! get_4d_scaled_noise {
     ($setting:expr) => {
         if is_x86_feature_detected!("avx2") {
@@ -203,6 +263,13 @@ macro_rules! get_4d_scaled_noise {
         } else {
             unsafe { scalar::get_4d_scaled_noise($setting) }
         }
+    };
+}
+
+#[cfg(not(any(target_arch = "x86", target_arch = "x86_64")))]
+macro_rules! get_4d_scaled_noise {
+    ($setting:expr) => {
+        unsafe { scalar::get_4d_scaled_noise($setting) }
     };
 }
 


### PR DESCRIPTION
This PR guards avx/sse related functionality behind a `#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]` to make compilation exclusively using the scalar implementation possible on non-x86 targets.
I am not familiar with this library, so tell me whether I missed anything. I compiled successfully with this library for AArch64.