### PR TITLE
Update simdeez to 1.0.7: fix "attempt to use a non-constant value in a constant"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 exclude = ["*.jpg"]
 name = "simdnoise"
-version = "3.1.6"
+version = "3.1.7"
 authors = ["Jack Mott <jack.mott@gmail.com>"]
 description = "SIMD accelerate noise library with runtime feature detection"
 license = "Apache-2.0/MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["game-engines", "multimedia::images"]
 edition = "2018"
 
 [dependencies]
-simdeez = "1.0.6"
+simdeez = "1.0.7"
 #simdeez = {path = "../simdeez"}
 
 [dev-dependencies]


### PR DESCRIPTION
This happens otherwise for nightly:
```
   Compiling simdeez v1.0.6
error[E0435]: attempt to use a non-constant value in a constant
   --> /home/linus/.cargo/registry/src/github.com-1ecc6299db9ec823/simdeez-1.0.6/src/avx2/avx2.rs:527:38
    |
521 |               let mask = _mm256_setr_epi32(0, -1, 0, -1, 0, -1, 0, -1); // mask for high part containing only sign
    |  ______________-
522 | |             Self::blendv_epi64(I64x4(sra3), I64x4(sign), I64x4(mask))
523 | |         }
524 | |     }
525 | |     #[inline(always)]
526 | |     unsafe fn srli_epi32(a: Self::Vi32, amt_const: i32) -> Self::Vi32 {
    | |_________________________________________________- help: consider using `const` instead of `let`: `const amt_const`
527 |           I32x8(_mm256_srli_epi32(a.0, amt_const))
    |
```