### PR TITLE
Use gain in 1D FBM noise (and use mul_add)

### DIFF
--- a/src/noise/fbm_32.rs
+++ b/src/noise/fbm_32.rs
@@ -16,7 +16,7 @@ pub fn fbm_1d<S: Simd>(
     for _ in 1..octaves {
         x = x * lacunarity;
         amp = amp * gain;
-        result = result + simplex_1d::<S>(x, seed);
+        result = (simplex_1d::<S>(x, seed) * amp) + result;
     }
 
     result

--- a/src/noise/fbm_32.rs
+++ b/src/noise/fbm_32.rs
@@ -16,7 +16,7 @@ pub fn fbm_1d<S: Simd>(
     for _ in 1..octaves {
         x = x * lacunarity;
         amp = amp * gain;
-        result = (simplex_1d::<S>(x, seed) * amp) + result;
+        result = simplex_1d::<S>(x, seed).mul_add(amp, result);
     }
 
     result
@@ -38,7 +38,7 @@ pub fn fbm_2d<S: Simd>(
         x = x * lac;
         y = y * lac;
         amp = amp * gain;
-        result = (simplex_2d::<S>(x, y, seed) * amp) + result;
+        result = simplex_2d::<S>(x, y, seed).mul_add(amp, result);
     }
 
     result
@@ -62,7 +62,7 @@ pub fn fbm_3d<S: Simd>(
         y = y * lac;
         z = z * lac;
         amp = amp * gain;
-        result = (simplex_3d::<S>(x, y, z, seed) * amp) + result;
+        result = simplex_3d::<S>(x, y, z, seed).mul_add(amp, result);
     }
 
     result
@@ -88,7 +88,7 @@ pub fn fbm_4d<S: Simd>(
         z = z * lac;
         w = w * lac;
         amp = amp * gain;
-        result = result + (simplex_4d::<S>(x, y, z, w, seed) * amp);
+        result = simplex_4d::<S>(x, y, z, w, seed).mul_add(amp, result);
     }
 
     result

--- a/src/noise/fbm_64.rs
+++ b/src/noise/fbm_64.rs
@@ -16,7 +16,7 @@ pub fn fbm_1d<S: Simd>(
     for _ in 1..octaves {
         x = x * lacunarity;
         amp = amp * gain;
-        result = result + simplex_1d::<S>(x, seed);
+        result = (simplex_1d::<S>(x, seed) * amp) + result;
     }
 
     result

--- a/src/noise/fbm_64.rs
+++ b/src/noise/fbm_64.rs
@@ -16,7 +16,7 @@ pub fn fbm_1d<S: Simd>(
     for _ in 1..octaves {
         x = x * lacunarity;
         amp = amp * gain;
-        result = (simplex_1d::<S>(x, seed) * amp) + result;
+        result = simplex_1d::<S>(x, seed).mul_add(amp, result);
     }
 
     result
@@ -38,7 +38,7 @@ pub fn fbm_2d<S: Simd>(
         x = x * lac;
         y = y * lac;
         amp = amp * gain;
-        result = (simplex_2d::<S>(x, y, seed) * amp) + result;
+        result = simplex_2d::<S>(x, y, seed).mul_add(amp, result);
     }
 
     result
@@ -61,7 +61,7 @@ pub fn fbm_3d<S: Simd>(
         y = y * lac;
         z = z * lac;
         amp = amp * gain;
-        result = (simplex_3d::<S>(x, y, z, seed) * amp) + result;
+        result = simplex_3d::<S>(x, y, z, seed).mul_add(amp, result);
     }
     result
 }
@@ -86,7 +86,7 @@ pub fn fbm_4d<S: Simd>(
         z = z * lac;
         w = w * lac;
         amp = amp * gain;
-        result = result + (simplex_4d::<S>(x, y, z, w, seed) * amp);
+        result = simplex_4d::<S>(x, y, z, w, seed).mul_add(amp, result);
     }
 
     result


### PR DESCRIPTION
It seems that 1D FBM noise was previously not using the `gain` setting. This implements that, and also uses fused multiply-add to accumulate the layers of noise if available (currently slower due to a bug, see https://github.com/arduano/simdeez/pull/78).

(Side note: The default value for `gain` is 2. This seems backwards--most FBM implementations have it set to 0.5 or 1/sqrt(2). [See the "Self Similarity" section of this article](https://iquilezles.org/articles/fbm/). Should the default be updated?)